### PR TITLE
Use base image

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -44,6 +44,8 @@ RUN apk add --no-cache \
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php5-dev php5-pear \
     yaml-dev zlib-dev libmemcached-dev cyrus-sasl-dev
 
+ENV PHP_INI_DIR /etc/php5
+
 RUN set -xe \
     && apk add --no-cache \
     --virtual .phpize-deps \
@@ -51,12 +53,12 @@ RUN set -xe \
     && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
     && pecl channel-update pecl.php.net \
     && pecl install yaml-1.3.1 memcached-2.2.0 \
-    && echo "extension=yaml.so" > /etc/php5/conf.d/yaml.ini \
-    && echo "extension=memcached.so" > /etc/php5/conf.d/memcached.ini \
+    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/yaml.ini \
+    && echo "extension=memcached.so" > $PHP_INI_DIR/conf.d/memcached.ini \
     && rm -rf /usr/share/php \
     && rm -rf /tmp/* \
     && apk del .phpize-deps
-COPY php/php.ini /etc/php5/
+COPY php/php.ini $PHP_INI_DIR/
 
 WORKDIR /srv
 

--- a/5.6/Dockerfile.debug
+++ b/5.6/Dockerfile.debug
@@ -1,73 +1,15 @@
-FROM alpine:3.5
-
-LABEL maintainer="developers@graze.com" \
-    license="MIT" \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.vendor="graze" \
-    org.label-schema.name="php-alpine" \
-    org.label-schema.description="small php image based on alpine" \
-    org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
+FROM graze/php-alpine:5.6
 
 RUN apk add --no-cache \
-    ca-certificates \
-    openssh-client \
-    libmemcached-libs \
-    yaml \
-    php5 \
-    php5-bcmath \
-    php5-ctype \
-    php5-curl \
-    php5-dom \
-    php5-iconv \
-    php5-intl \
-    php5-json \
-    php5-openssl \
-    php5-opcache \
-    php5-mcrypt \
-    php5-mysqli \
-    php5-pgsql \
-    php5-pdo_mysql \
-    php5-pdo_pgsql \
-    php5-pdo_sqlite \
-    php5-phar \
-    php5-posix \
-    php5-soap \
-    php5-sockets \
-    php5-xdebug \
-    php5-xml \
-    php5-xmlreader \
-    php5-zip \
-    php5-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-    gnu-libiconv
-
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php5-dev php5-pear \
-    yaml-dev zlib-dev libmemcached-dev cyrus-sasl-dev
+    php5-xdebug
 
 RUN set -xe \
-    && apk add --no-cache \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml-1.3.1 memcached-2.2.0 \
-    && echo "extension=yaml.so" > /etc/php5/conf.d/yaml.ini \
-    && echo "extension=memcached.so" > /etc/php5/conf.d/memcached.ini \
-    && echo "zend_extension=xdebug.so" >> /etc/php5/conf.d/xdebug.ini \
-    && rm -rf /usr/share/php \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
+    && echo "zend_extension=xdebug.so" >> $PHP_INI_DIR/conf.d/xdebug.ini
 
-COPY php/php.ini /etc/php5/
-
-WORKDIR /srv
+COPY php/php.ini $PHP_INI_DIR/
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.build-date=$BUILD_DATE
-
-# Fix for iconv: https://github.com/docker-library/php/issues/240
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -49,6 +49,8 @@ RUN apk add --no-cache \
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     yaml-dev pcre-dev zlib-dev libmemcached-dev cyrus-sasl-dev
 
+ENV PHP_INI_DIR /etc/php7
+
 RUN set -xe \
     && apk add --no-cache \
     --virtual .phpize-deps \
@@ -56,16 +58,16 @@ RUN set -xe \
     && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
     && pecl channel-update pecl.php.net \
     && pecl install yaml apcu memcached \
-    && echo "extension=yaml.so" > /etc/php7/conf.d/01_yaml.ini \
-    && echo "extension=apcu.so" > /etc/php7/conf.d/01_apcu.ini \
-    && echo "extension=memcached.so" > /etc/php7/conf.d/20_memcached.ini \
+    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/01_yaml.ini \
+    && echo "extension=apcu.so" > $PHP_INI_DIR/conf.d/01_apcu.ini \
+    && echo "extension=memcached.so" > $PHP_INI_DIR/conf.d/20_memcached.ini \
     && rm -rf /usr/share/php7 \
     && rm -rf /tmp/* \
     && apk del .phpize-deps
 
 RUN ln -s /usr/bin/php7 /usr/bin/php
 
-COPY php/php.ini /etc/php7/
+COPY php/php.ini $PHP_INI_DIR/
 
 WORKDIR /srv
 

--- a/7.0/Dockerfile.debug
+++ b/7.0/Dockerfile.debug
@@ -1,80 +1,10 @@
-FROM alpine:3.5
-
-LABEL maintainer="developers@graze.com" \
-    license="MIT" \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.vendor="graze" \
-    org.label-schema.name="php-alpine" \
-    org.label-schema.description="small php image based on alpine" \
-    org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
+FROM graze/php-alpine:7.0
 
 RUN apk add --no-cache \
-    ca-certificates \
-    openssh-client \
-    yaml \
-    pcre \
-    libmemcached-libs \
-    zlib \
-    php7 \
-    php7-bcmath \
-    php7-ctype \
-    php7-curl \
-    php7-dom \
-    php7-iconv \
-    php7-intl \
-    php7-json \
-    php7-openssl \
-    php7-opcache \
-    php7-mbstring \
-    php7-mcrypt \
-    php7-mysqlnd \
-    php7-mysqli \
-    php7-pgsql \
-    php7-pdo_mysql \
-    php7-pdo_pgsql \
-    php7-pdo_sqlite \
-    php7-phar \
-    php7-phpdbg \
-    php7-posix \
-    php7-session \
-    php7-soap \
-    php7-sockets \
-    php7-xml \
-    php7-xmlreader \
-    php7-zip \
-    php7-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-    gnu-libiconv
-
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
-    yaml-dev pcre-dev zlib-dev libmemcached-dev cyrus-sasl-dev
-
-RUN set -xe \
-    && apk add --no-cache \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml apcu memcached \
-    && echo "extension=yaml.so" > /etc/php7/conf.d/01_yaml.ini \
-    && echo "extension=apcu.so" > /etc/php7/conf.d/01_apcu.ini \
-    && echo "extension=memcached.so" > /etc/php7/conf.d/20_memcached.ini \
-    && rm -rf /usr/share/php7 \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
-
-RUN ln -s /usr/bin/php7 /usr/bin/php
-
-COPY php/php.ini /etc/php7/
-
-WORKDIR /srv
+    php7-phpdbg
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.build-date=$BUILD_DATE
-
-# Fix for iconv: https://github.com/docker-library/php/issues/240
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -54,6 +54,8 @@ RUN apk add --no-cache \
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     yaml-dev
 
+ENV PHP_INI_DIR /etc/php7
+
 RUN set -xe \
     && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
     --virtual .phpize-deps \
@@ -61,12 +63,12 @@ RUN set -xe \
     && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
     && pecl channel-update pecl.php.net \
     && pecl install yaml \
-    && echo "extension=yaml.so" > /etc/php7/conf.d/01_yaml.ini \
+    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/01_yaml.ini \
     && rm -rf /usr/share/php7 \
     && rm -rf /tmp/* \
     && apk del .phpize-deps
 
-COPY php/conf.d/00_memlimit.ini /etc/php7/conf.d/00_memlimit.ini
+COPY php/conf.d/00_memlimit.ini $PHP_INI_DIR/conf.d/00_memlimit.ini
 
 WORKDIR /srv
 

--- a/7.1/Dockerfile.debug
+++ b/7.1/Dockerfile.debug
@@ -1,81 +1,10 @@
-FROM alpine:edge
-
-LABEL maintainer="developers@graze.com" \
-    license="MIT" \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.vendor="graze" \
-    org.label-schema.name="php-alpine" \
-    org.label-schema.description="small php image based on alpine" \
-    org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
+FROM graze/php-alpine:7.1
 
 RUN apk add --no-cache \
-    ca-certificates \
-    openssh-client \
-    libmemcached-libs \
-    musl \
-    yaml \
-    php7 \
-    php7-apcu \
-    php7-bcmath \
-    php7-ctype \
-    php7-curl \
-    php7-dom \
-    php7-fileinfo \
-    php7-iconv \
-    php7-intl \
-    php7-json \
-    php7-openssl \
-    php7-opcache \
-    php7-memcached \
-    php7-mbstring \
-    php7-mcrypt \
-    php7-mysqlnd \
-    php7-mysqli \
-    php7-pgsql \
-    php7-phpdbg \
-    php7-pdo_mysql \
-    php7-pdo_pgsql \
-    php7-pdo_sqlite \
-    php7-phar \
-    php7-posix \
-    php7-session \
-    php7-simplexml \
-    php7-soap \
-    php7-sockets \
-    php7-tokenizer \
-    php7-xml \
-    php7-xmlreader \
-    php7-xmlwriter \
-    php7-zip \
-    php7-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-    gnu-libiconv
-
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
-    yaml-dev
-
-RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml \
-    && echo "extension=yaml.so" > /etc/php7/conf.d/01_yaml.ini \
-    && rm -rf /usr/share/php7 \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
-
-COPY php/conf.d/00_memlimit.ini /etc/php7/conf.d/00_memlimit.ini
-
-WORKDIR /srv
+    php7-phpdbg
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.build-date=$BUILD_DATE
-
-# Fix for iconv: https://github.com/docker-library/php/issues/240
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build_args := --build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
 .DEFAULT: build
 build: build-5.6 build-7.0 build-7.1
 build-quick:
-	make build cache=""
+	make build cache="" pull=""
 
 tag: tag-5.6 tag-7.0 tag-7.1
 test: test-5.6 test-7.0 test-7.1
@@ -27,9 +27,10 @@ push: push-5.6 push-7.0 push-7.1
 clean: clean-5.6 clean-7.0 clean-7.1
 deploy: deploy-5.6 deploy-7.0 deploy-7.1
 
-build-%: cache ?=--pull --no-cache
+build-%: cache ?= --no-cache
+build-%: pull ?= --pull
 build-%: ## build a generic image
-	docker build ${build_args} ${cache} -t graze/php-alpine:$* $*/.
+	docker build ${build_args} ${cache} ${pull} -t graze/php-alpine:$* $*/.
 	docker build ${build_args} ${cache} -t graze/php-alpine:$*-test -f $*/Dockerfile.debug $*/.
 
 clean-%: ## Clean up the images


### PR DESCRIPTION
don't completely re-build the test images, use the normal images as a base.

- adds `PHP_INI_DIR` so other stuff can use it