### PR TITLE
lock apcu to coderocks version

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -13,6 +13,7 @@ ADD https://php.codecasts.rocks/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.
 
 RUN set -xe \
     && echo "https://php.codecasts.rocks/v3.7/php-7.2" >> /etc/apk/repositories \
+    && echo "@php https://php.codecasts.rocks/v3.7/php-7.2" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     openssh-client \
@@ -22,7 +23,7 @@ RUN set -xe \
     musl \
     yaml \
     php7 \
-    php7-apcu \
+    php7-apcu@php \
     php7-bcmath \
     php7-ctype \
     php7-curl \

--- a/7.2/php.bats
+++ b/7.2/php.bats
@@ -81,6 +81,7 @@ readonly container="graze/php-alpine:7.2"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
+  [[ "${output}" != *"mcrypt"* ]]
   [[ "${output}" == *"apcu"* ]]
   [[ "${output}" == *"bcmath"* ]]
   [[ "${output}" == *"Core"* ]]

--- a/7.2/php_debug.bats
+++ b/7.2/php_debug.bats
@@ -81,6 +81,7 @@ readonly container="graze/php-alpine:7.2-test"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
+  [[ "${output}" != *"mcrypt"* ]]
   [[ "${output}" == *"apcu"* ]]
   [[ "${output}" == *"bcmath"* ]]
   [[ "${output}" == *"Core"* ]]


### PR DESCRIPTION
Issue: The version of `php7-apcu` is the same in the main repository and the coderocks repository. It was using the one from the main repo, it should use the coderocks one as it is built with the same php version.

- Fixes the php7.2 build