### PR TITLE
Fix broken 7.3 image

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -12,6 +12,8 @@ LABEL maintainer="developers@graze.com" \
 ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
 
 RUN set -xe \
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    gnu-libiconv \
     && echo "https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \
     && echo "@php https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \
     && apk add --update --no-cache \
@@ -52,9 +54,7 @@ RUN set -xe \
     php-xml \
     php-xmlreader \
     php-zip \
-    php-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
-    gnu-libiconv
+    php-zlib
 
 # install and remove building packages
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php-dev php-pear \


### PR DESCRIPTION
The 7.3 image has been slightly broken since [June 2019](https://travis-ci.org/graze/docker-php-alpine/jobs/545931627#L529). The breakage was because of the installation of `gnu-libiconv` which caused `php-zlib` to be uninstalled for reasons I have not yet been able to identify.

```
(1/3) Installing gnu-libiconv (1.15-r2)
(2/3) Purging php7-zlib (7.3.5-r1)
(3/3) Upgrading php7-common (7.3.5-r1 -> 7.3.6-r0)
```

The [previous daily build](https://travis-ci.org/graze/docker-php-alpine/jobs/545454140#L530) installed the exact same version (1.15-r2) but did not cause this problem.

Note that anyone using the 7.3 image would not encounter a problem unless they were trying to using zlib functionality.

This PR fixes the problem by ensuring that `gnu-libiconv` is installed first. 🤷🏼‍♂️