### PR TITLE
Fix broken 7.4 image

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -12,6 +12,8 @@ LABEL maintainer="developers@graze.com" \
 ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
 
 RUN set -xe \
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    gnu-libiconv \
     && echo "https://dl.bintray.com/php-alpine/v3.9/php-7.4" >> /etc/apk/repositories \
     && echo "@php https://dl.bintray.com/php-alpine/v3.9/php-7.4" >> /etc/apk/repositories \
     && apk add --update --no-cache \
@@ -52,9 +54,7 @@ RUN set -xe \
     php-xml \
     php-xmlreader \
     php-zip \
-    php-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
-    gnu-libiconv
+    php-zlib
 
 # install and remove building packages
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php-dev php-pear \


### PR DESCRIPTION
This is basically fixes the exact same problem as https://github.com/graze/docker-php-alpine/pull/27 but for the 7.4 image. The build has been broken since [June 2020](https://travis-ci.org/github/graze/docker-php-alpine/jobs/698746819). The 7.3 build started breaking in June 2019. Co-incidence? Who knows.

See the above PR description for more details.