### PR TITLE
Update PHP 7.4

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.12
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -14,8 +14,8 @@ ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-a
 RUN set -xe \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
     gnu-libiconv \
-    && echo "https://dl.bintray.com/php-alpine/v3.9/php-7.4" >> /etc/apk/repositories \
-    && echo "@php https://dl.bintray.com/php-alpine/v3.9/php-7.4" >> /etc/apk/repositories \
+    && echo "https://dl.bintray.com/php-alpine/v3.12/php-7.4" >> /etc/apk/repositories \
+    && echo "@php https://dl.bintray.com/php-alpine/v3.12/php-7.4" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     curl \


### PR DESCRIPTION
Our PCI scan requires us to meet these requirements:

```
PHP before 7.2.x below 7.2.34, 7.3.x below 7.3.23 and 7.4.x below 7.4.11 
```

There's no update to 7.3 in [PHP alpine](https://github.com/codecasts/php-alpine) that meets this criteria, but there is one for PHP 7.4.