### PR TITLE
Downgrade alpine version from 3.12 to 3.11

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.11
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -14,8 +14,8 @@ ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-a
 RUN set -xe \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
     gnu-libiconv \
-    && echo "https://dl.bintray.com/php-alpine/v3.12/php-7.4" >> /etc/apk/repositories \
-    && echo "@php https://dl.bintray.com/php-alpine/v3.12/php-7.4" >> /etc/apk/repositories \
+    && echo "https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
+    && echo "@php https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     curl \


### PR DESCRIPTION
This addresses an upstream problem in alpine 3.12.

https://github.com/codecasts/php-alpine/issues/117

Both versions of alpine contain PHP 7.4.13 and so this change has no
negative impact on this docker image.