### PR TITLE
Fix iconv breakage

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -40,7 +40,8 @@ RUN apk add --no-cache \
     php5-xmlreader \
     php5-zip \
     php5-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
     gnu-libiconv
 
 # install and remove building packages

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -44,7 +44,8 @@ RUN apk add --no-cache \
     php7-xmlreader \
     php7-zip \
     php7-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
     gnu-libiconv
 
 # install and remove building packages

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -52,7 +52,8 @@ RUN set -xe \
     php7-xmlwriter \
     php7-zip \
     php7-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
     gnu-libiconv
 
 # install and remove building packages

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -54,7 +54,8 @@ RUN set -xe \
     php7-yaml \
     php7-zip \
     php7-zlib \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
     gnu-libiconv
 
 # install and remove building packages

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer="developers@graze.com" \
 ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
 
 RUN set -xe \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
+    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
     gnu-libiconv \
     && echo "https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \
     && echo "@php https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -12,13 +12,12 @@ LABEL maintainer="developers@graze.com" \
 ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
 
 RUN set -xe \
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted \
-    gnu-libiconv \
     && echo "https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
     && echo "@php https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     curl \
+    gnu-libiconv \
     openssh-client \
     libmemcached-libs \
     libevent \


### PR DESCRIPTION
# Background

`iconv` does not work correctly under the vanilla alpine image as per https://github.com/docker-library/php/issues/240 so all the images in this repo use the solution given in that bug report (ie. install `gnu-libiconv` and use `LD_PRELOAD` with the library it supplies). This has so far been taken from the `edge` version of alpine.

# The problem

Unfortunately `edge` now contains version 1.16 of `gnu-libiconv` which no longer contains the preload library, as mentioned here:

https://gitlab.alpinelinux.org/alpine/aports/-/issues/12328

The consequence is on a newly built image, `iconv` will not work correctly. This is manifested by the following test failure:

    not ok 13 iconv works
    # (in test file common/php.bats, line 105)
    #   `[ "$output" = "foobar" ]' failed
    # status: 0
    # output: PHP Warning:  iconv(): Wrong encoding, conversion from "UTF-8" to "ASCII//TRANSLIT" is not allowed in Command line code on line 1

# The fix

The fix is to pin the version of `gnu-libiconv` installed to a version prior to 1.16. This package was first introduced in alpine 3.10 and so the following changes were made:

- For images based on <3.10, then install it separately from 3.10.
- For images based on >=3.10, then install it as part of the regular package installation.

# The future

The latest version of alpine at the time of writing is 3.13 which contains version 1.15-rc3 of `gnu-libiconv`. I would guess that alpine 3.14 would contain version 1.16. If any future images for this repo _require_ alpine 3.14 or above (eg. for PHP 8.x), then we will have to think of a suitable solution to this problem.