### PR TITLE
Remove dependency on bintray

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -54,7 +54,9 @@ RUN set -xe \
     php7-zlib \
     # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
-    gnu-libiconv
+    gnu-libiconv \
+    php7-common=~7.1
+
 
 # install and remove building packages
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
@@ -63,7 +65,7 @@ ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-p
 ENV PHP_INI_DIR /etc/php7
 
 RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
+    && apk add --no-cache \
     --virtual .phpize-deps \
     $PHPIZE_DEPS \
     && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -65,7 +65,7 @@ ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-p
 ENV PHP_INI_DIR /etc/php7
 
 RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
+    && apk add --no-cache \
     --virtual .phpize-deps \
     $PHPIZE_DEPS \
     && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.12
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -8,16 +8,9 @@ LABEL maintainer="developers@graze.com" \
     org.label-schema.description="small php image based on alpine" \
     org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
 
-# trust this project public key to trust the packages.
-ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
-
 RUN set -xe \
-    # alpine 3.10 is the first version that provides a gnu-libiconv with the preload library needed
-    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/community/ --allow-untrusted \
-    gnu-libiconv \
-    && echo "https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \
-    && echo "@php https://dl.bintray.com/php-alpine/v3.9/php-7.3" >> /etc/apk/repositories \
     && apk add --update --no-cache \
+    gnu-libiconv \
     ca-certificates \
     curl \
     openssh-client \
@@ -26,44 +19,42 @@ RUN set -xe \
     libssl1.1 \
     musl \
     yaml \
-    php \
-    php-apcu \
-    php-bcmath \
-    php-ctype \
-    php-curl \
-    php-dom \
-    php-iconv \
-    php-intl \
-    php-json \
-    php-openssl \
-    php-opcache \
-    php-mbstring \
-    php-memcached \
-    php-mysqlnd \
-    php-mysqli \
-    php-pcntl \
-    php-pgsql \
-    php-pdo_mysql \
-    php-pdo_pgsql \
-    php-pdo_sqlite \
-    php-phar \
-    php-posix \
-    php-session \
-    php-soap \
-    php-sockets \
-    php-sodium \
-    php-xml \
-    php-xmlreader \
-    php-zip \
-    php-zlib
+    php7 \
+    php7-apcu \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-dom \
+    php7-iconv \
+    php7-intl \
+    php7-json \
+    php7-openssl \
+    php7-opcache \
+    php7-mbstring \
+    php7-memcached \
+    php7-mysqlnd \
+    php7-mysqli \
+    php7-pcntl \
+    php7-pgsql \
+    php7-pdo_mysql \
+    php7-pdo_pgsql \
+    php7-pdo_sqlite \
+    php7-phar \
+    php7-posix \
+    php7-session \
+    php7-soap \
+    php7-sockets \
+    php7-sodium \
+    php7-xml \
+    php7-xmlreader \
+    php7-zip \
+    php7-zlib
 
 # install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php-dev php-pear \
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     yaml-dev libevent-dev openssl-dev
 
 ENV PHP_INI_DIR /etc/php7
-
-RUN ln -s /usr/bin/php7 /usr/bin/php
 
 RUN set -xe \
     && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -28,6 +28,7 @@ RUN set -xe \
     php7-ctype \
     php7-curl \
     php7-dom \
+    php7-fileinfo \
     php7-iconv \
     php7-intl \
     php7-json \
@@ -43,12 +44,15 @@ RUN set -xe \
     php7-pdo_sqlite \
     php7-phar \
     php7-posix \
+    php7-simplexml \
     php7-session \
     php7-soap \
     php7-sockets \
     php7-sodium \
+    php7-tokenizer \
     php7-xml \
     php7-xmlreader \
+    php7-xmlwriter \
     php7-zip \
     php7-zlib
 

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -20,7 +20,10 @@ RUN set -xe \
     musl \
     yaml \
     php7 \
-    php7-apcu \
+    php7-pecl-apcu \
+    php7-pecl-event \
+    php7-pecl-memcached \
+    php7-pecl-yaml \
     php7-bcmath \
     php7-ctype \
     php7-curl \
@@ -31,7 +34,6 @@ RUN set -xe \
     php7-openssl \
     php7-opcache \
     php7-mbstring \
-    php7-memcached \
     php7-mysqlnd \
     php7-mysqli \
     php7-pcntl \
@@ -50,24 +52,7 @@ RUN set -xe \
     php7-zip \
     php7-zlib
 
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
-    yaml-dev libevent-dev openssl-dev
-
 ENV PHP_INI_DIR /etc/php7
-
-RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml event \
-    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/01_yaml.ini \
-    && echo "extension=event.so" > $PHP_INI_DIR/conf.d/01_event.ini \
-    && rm -rf /usr/share/php7 \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
 
 COPY php/conf.d/*.ini $PHP_INI_DIR/conf.d/
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -28,6 +28,7 @@ RUN set -xe \
     php7-ctype \
     php7-curl \
     php7-dom \
+    php7-fileinfo \
     php7-iconv \
     php7-intl \
     php7-json \
@@ -43,12 +44,15 @@ RUN set -xe \
     php7-pdo_sqlite \
     php7-phar \
     php7-posix \
+    php7-simplexml \
     php7-session \
     php7-soap \
     php7-sockets \
     php7-sodium \
+    php7-tokenizer \
     php7-xml \
     php7-xmlreader \
+    php7-xmlwriter \
     php7-zip \
     php7-zlib
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -20,7 +20,10 @@ RUN set -xe \
     musl \
     yaml \
     php7 \
-    php7-apcu \
+    php7-pecl-apcu \
+    php7-pecl-event \
+    php7-pecl-memcached \
+    php7-pecl-yaml \
     php7-bcmath \
     php7-ctype \
     php7-curl \
@@ -31,7 +34,6 @@ RUN set -xe \
     php7-openssl \
     php7-opcache \
     php7-mbstring \
-    php7-memcached \
     php7-mysqlnd \
     php7-mysqli \
     php7-pcntl \
@@ -50,24 +52,7 @@ RUN set -xe \
     php7-zip \
     php7-zlib
 
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
-    yaml-dev libevent-dev openssl-dev
-
 ENV PHP_INI_DIR /etc/php7
-
-RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml event \
-    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/01_yaml.ini \
-    && echo "extension=event.so" > $PHP_INI_DIR/conf.d/01_event.ini \
-    && rm -rf /usr/share/php7 \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
 
 COPY php/conf.d/*.ini $PHP_INI_DIR/conf.d/
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.13
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -8,12 +8,7 @@ LABEL maintainer="developers@graze.com" \
     org.label-schema.description="small php image based on alpine" \
     org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
 
-# trust this project public key to trust the packages.
-ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
-
 RUN set -xe \
-    && echo "https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
-    && echo "@php https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     curl \
@@ -24,44 +19,42 @@ RUN set -xe \
     libssl1.1 \
     musl \
     yaml \
-    php \
-    php-apcu \
-    php-bcmath \
-    php-ctype \
-    php-curl \
-    php-dom \
-    php-iconv \
-    php-intl \
-    php-json \
-    php-openssl \
-    php-opcache \
-    php-mbstring \
-    php-memcached \
-    php-mysqlnd \
-    php-mysqli \
-    php-pcntl \
-    php-pgsql \
-    php-pdo_mysql \
-    php-pdo_pgsql \
-    php-pdo_sqlite \
-    php-phar \
-    php-posix \
-    php-session \
-    php-soap \
-    php-sockets \
-    php-sodium \
-    php-xml \
-    php-xmlreader \
-    php-zip \
-    php-zlib
+    php7 \
+    php7-apcu \
+    php7-bcmath \
+    php7-ctype \
+    php7-curl \
+    php7-dom \
+    php7-iconv \
+    php7-intl \
+    php7-json \
+    php7-openssl \
+    php7-opcache \
+    php7-mbstring \
+    php7-memcached \
+    php7-mysqlnd \
+    php7-mysqli \
+    php7-pcntl \
+    php7-pgsql \
+    php7-pdo_mysql \
+    php7-pdo_pgsql \
+    php7-pdo_sqlite \
+    php7-phar \
+    php7-posix \
+    php7-session \
+    php7-soap \
+    php7-sockets \
+    php7-sodium \
+    php7-xml \
+    php7-xmlreader \
+    php7-zip \
+    php7-zlib
 
 # install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php-dev php-pear \
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     yaml-dev libevent-dev openssl-dev
 
 ENV PHP_INI_DIR /etc/php7
-
-RUN ln -s /usr/bin/php7 /usr/bin/php
 
 RUN set -xe \
     && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -29,6 +29,7 @@ RUN set -xe \
     php8-ctype \
     php8-curl \
     php8-dom \
+    php8-fileinfo \
     php8-iconv \
     php8-intl \
     php8-openssl \
@@ -43,12 +44,15 @@ RUN set -xe \
     php8-pdo_sqlite \
     php8-phar \
     php8-posix \
+    php8-simplexml \
     php8-session \
     php8-soap \
     php8-sockets \
     php8-sodium \
+    php8-tokenizer \
     php8-xml \
     php8-xmlreader \
+    php8-xmlwriter \
     php8-zip \
     php8-zlib
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -8,12 +8,7 @@ LABEL maintainer="developers@graze.com" \
     org.label-schema.description="small php image based on alpine" \
     org.label-schema.vcs-url="https://github.com/graze/docker-php-alpine"
 
-# trust this project public key to trust the packages.
-ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
-
 RUN set -xe \
-    && echo "https://dl.bintray.com/php-alpine/v3.12/php-8.0" >> /etc/apk/repositories \
-    && echo "@php https://dl.bintray.com/php-alpine/v3.12/php-8.0" >> /etc/apk/repositories \
     && apk add --update --no-cache \
     ca-certificates \
     curl \
@@ -25,7 +20,8 @@ RUN set -xe \
     musl \
     yaml \
     php8 \
-    php8-apcu \
+    php8-pecl-apcu \
+    php8-pecl-memcached \
     php8-bcmath \
     php8-common \
     php8-ctype \
@@ -36,7 +32,6 @@ RUN set -xe \
     php8-openssl \
     php8-opcache \
     php8-mbstring \
-    php8-memcached \
     php8-mysqlnd \
     php8-mysqli \
     php8-pcntl \
@@ -56,12 +51,13 @@ RUN set -xe \
     php8-zlib
 
 # install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php-dev php-pear \
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php8-dev php8-pear \
     yaml-dev libevent-dev openssl-dev
 
 ENV PHP_INI_DIR /etc/php8
 
 RUN ln -s /usr/bin/php8 /usr/bin/php
+RUN ln -s /usr/bin/pecl8 /usr/bin/pecl
 
 RUN set -xe \
     && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -21,7 +21,9 @@ RUN set -xe \
     yaml \
     php8 \
     php8-pecl-apcu \
+    php8-pecl-event \
     php8-pecl-memcached \
+    php8-pecl-yaml \
     php8-bcmath \
     php8-common \
     php8-ctype \
@@ -50,28 +52,10 @@ RUN set -xe \
     php8-zip \
     php8-zlib
 
-# install and remove building packages
-ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php8-dev php8-pear \
-    yaml-dev libevent-dev openssl-dev
-
 ENV PHP_INI_DIR /etc/php8
 
 RUN ln -s /usr/bin/php8 /usr/bin/php
 RUN ln -s /usr/bin/pecl8 /usr/bin/pecl
-
-RUN set -xe \
-    && apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl channel-update pecl.php.net \
-    && pecl install yaml \
-    event \
-    && echo "extension=yaml.so" > $PHP_INI_DIR/conf.d/01_yaml.ini \
-    && echo "extension=event.so" > $PHP_INI_DIR/conf.d/01_event.ini \
-    && rm -rf /usr/share/php8 \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
 
 COPY php/conf.d/*.ini $PHP_INI_DIR/conf.d/
 


### PR DESCRIPTION
Re: https://github.com/graze/docker-php-alpine/issues/36 - this removes the bintray repos for PHP 7.3, 7.4 and 8.0.



Tests are passing.

Few notes:
- Also fixed broken builds for 7.1 + 7.2 regarding dev dependencies for libreadline.
- PHP versions 7.3+ have pecl-event and pecl-yaml in the main repos, so manual compiling is removed.